### PR TITLE
Speedup DB#range by seeking to the start of the range.

### DIFF
--- a/lib/leveldb/iterator.rb
+++ b/lib/leveldb/iterator.rb
@@ -37,6 +37,8 @@ module LevelDB
     def range(from, to, &block)
       @_range = [from.to_s, to.to_s].sort
       @_range = @_range.reverse if reverse?
+      C.iter_seek(@_iterator, @_range.first, @_range.first.bytesize) if !reverse?
+
       each(&block)
     end
 


### PR DESCRIPTION
Current behavior iterates through all keys prior to the start of the range, this is much quicker for large databases.
