### PR TITLE
Fix bundler not actually built leveldb

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "ext/leveldb"]
 	path = ext/leveldb
-	url = https://code.google.com/p/leveldb/
+	url = https://github.com/google/leveldb.git

--- a/ext/Rakefile
+++ b/ext/Rakefile
@@ -7,5 +7,5 @@ task :default do
   end
 
   # Make sure leveldb is built...
-  sh "cd #{leveldb_dir} && make"
+  system "cd #{leveldb_dir} && make" || exit(1)
 end


### PR DESCRIPTION
* `sh` is deprecated after ruby 2.2.9
* Return error when shell command fails